### PR TITLE
Potential fix for code scanning alert no. 2: Unused variable, import, function or class

### DIFF
--- a/lib/generateEmbedding.ts
+++ b/lib/generateEmbedding.ts
@@ -1,5 +1,5 @@
 // /lib/generateEmbedding.ts
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 
 /**
  * Generates an embedding for a given text using the Nomic Embeddings API.


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/Holding-1-at-a-time/my-ai-app/security/code-scanning/2](https://github.com/Holding-1-at-a-time/my-ai-app/security/code-scanning/2)

To fix the problem, we need to remove the unused `AxiosError` import from the code. This will clean up the code and avoid any confusion about the usage of `AxiosError`. The change should be made in the file `lib/generateEmbedding.ts` on line 2.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Chores:
- Removes unused `AxiosError` import from `lib/generateEmbedding.ts`.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed unused `AxiosError` import from `lib/generateEmbedding.ts`.

- Cleaned up code to resolve code scanning alert.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generateEmbedding.ts</strong><dd><code>Remove unused `AxiosError` import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/generateEmbedding.ts

<li>Removed the unused <code>AxiosError</code> import.<br> <li> Simplified the import statement for <code>axios</code>.


</details>


  </td>
  <td><a href="https://github.com/Holding-1-at-a-time/my-ai-app/pull/3/files#diff-f00cd0b2598fef20cb99a280cd810cf414457c1fb07373408ad9f6dc031eb930">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>